### PR TITLE
Add MCP browser onboarding flow

### DIFF
--- a/lib/core/router.dart
+++ b/lib/core/router.dart
@@ -7,6 +7,10 @@ import 'package:nova3d_frontend/features/auth/presentation/oauth_callback_page.d
 import 'package:nova3d_frontend/features/auth/presentation/sign_in_page.dart';
 import 'package:nova3d_frontend/features/auth/presentation/sign_up_page.dart';
 import 'package:nova3d_frontend/features/auth/state/auth_provider.dart';
+import 'package:nova3d_frontend/features/mcp/presentation/mcp_complete_page.dart';
+import 'package:nova3d_frontend/features/mcp/presentation/mcp_connect_page.dart';
+import 'package:nova3d_frontend/features/mcp/presentation/mcp_no_credits_page.dart';
+import 'package:nova3d_frontend/features/mcp/presentation/mcp_purchase_success_page.dart';
 import 'package:nova3d_frontend/shared/models/user_model.dart';
 import 'package:nova3d_frontend/features/account_api_keys/presentation/account_api_keys_page.dart';
 import 'package:nova3d_frontend/features/chat/presentation/chat_page.dart';
@@ -58,6 +62,10 @@ final routerProvider = Provider<GoRouter>((ref) {
         '/forgot-password',
         '/oauth-callback',
         '/success',
+        '/mcp/connect',
+        '/mcp/complete',
+        '/mcp/no-credits',
+        '/mcp/purchase-success',
       };
       const authEntryPaths = {
         '/signin',
@@ -95,6 +103,26 @@ final routerProvider = Provider<GoRouter>((ref) {
         path: '/success',
         pageBuilder: (_, state) =>
             _fadePage(state.pageKey, const PaymentSuccessPage()),
+      ),
+      GoRoute(
+        path: '/mcp/connect',
+        pageBuilder: (_, state) =>
+            _fadePage(state.pageKey, const McpConnectPage()),
+      ),
+      GoRoute(
+        path: '/mcp/complete',
+        pageBuilder: (_, state) =>
+            _fadePage(state.pageKey, const McpCompletePage()),
+      ),
+      GoRoute(
+        path: '/mcp/no-credits',
+        pageBuilder: (_, state) =>
+            _fadePage(state.pageKey, const McpNoCreditsPage()),
+      ),
+      GoRoute(
+        path: '/mcp/purchase-success',
+        pageBuilder: (_, state) =>
+            _fadePage(state.pageKey, const McpPurchaseSuccessPage()),
       ),
 
       // ── Authenticated shell ──────────────────────────────────────────────

--- a/lib/features/auth/presentation/oauth_callback_page.dart
+++ b/lib/features/auth/presentation/oauth_callback_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:nova3d_frontend/core/theme.dart';
+import 'package:nova3d_frontend/features/mcp/data/mcp_browser_context.dart';
 import 'package:nova3d_frontend/features/auth/state/auth_provider.dart';
 import 'package:web/web.dart' as web;
 
@@ -48,7 +49,10 @@ class _OAuthCallbackPageState extends ConsumerState<OAuthCallbackPage> {
 
     try {
       await ref.read(authProvider.notifier).handleOAuthCallback(token);
-      if (mounted) context.go('/');
+      final mcpContext = McpBrowserContext.read();
+      if (mounted) {
+        context.go(mcpContext != null ? '/mcp/complete' : '/');
+      }
     } catch (e, st) {
       debugPrint('[OAuthCallback] auth failed: $e\n$st');
       if (mounted) context.go('/signin?error=auth_failed');
@@ -57,17 +61,16 @@ class _OAuthCallbackPageState extends ConsumerState<OAuthCallbackPage> {
 
   @override
   Widget build(BuildContext context) => const Scaffold(
-        backgroundColor: kBgDark,
-        body: Center(
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              CircularProgressIndicator(color: kAccentBlue),
-              SizedBox(height: 16),
-              Text('Finishing sign-in…',
-                  style: TextStyle(color: kTextSecondary)),
-            ],
-          ),
-        ),
-      );
+    backgroundColor: kBgDark,
+    body: Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          CircularProgressIndicator(color: kAccentBlue),
+          SizedBox(height: 16),
+          Text('Finishing sign-in…', style: TextStyle(color: kTextSecondary)),
+        ],
+      ),
+    ),
+  );
 }

--- a/lib/features/auth/presentation/sign_in_page.dart
+++ b/lib/features/auth/presentation/sign_in_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:nova3d_frontend/core/theme.dart';
+import 'package:nova3d_frontend/features/mcp/data/mcp_browser_context.dart';
 import 'package:nova3d_frontend/features/auth/state/auth_provider.dart';
 import 'package:nova3d_frontend/shared/widgets/grid_background.dart';
 import 'package:nova3d_frontend/shared/widgets/nova_logo.dart';
@@ -18,7 +19,15 @@ class _SignInPageState extends ConsumerState<SignInPage> {
   bool _loading = false;
   String? _error;
 
+  @override
+  void initState() {
+    super.initState();
+    // Normal web sign-in should never inherit an abandoned MCP handoff context.
+    McpBrowserContext.clear();
+  }
+
   Future<void> _googleSignIn() async {
+    McpBrowserContext.clear();
     setState(() {
       _loading = true;
       _error = null;

--- a/lib/features/mcp/data/mcp_browser_context.dart
+++ b/lib/features/mcp/data/mcp_browser_context.dart
@@ -1,0 +1,104 @@
+import 'dart:convert';
+
+import 'package:web/web.dart' as web;
+
+const String _mcpContextStorageKey = '_nova3d_mcp_context';
+
+class McpBrowserContext {
+  const McpBrowserContext({
+    required this.state,
+    required this.port,
+    this.clientName,
+  });
+
+  final String state;
+  final int port;
+  final String? clientName;
+
+  bool get isValid => state.trim().isNotEmpty && port > 0;
+
+  Uri get loopbackUri => Uri(
+    scheme: 'http',
+    host: '127.0.0.1',
+    port: port,
+    path: '/',
+    queryParameters: {'code': '{code}', 'state': state},
+  );
+
+  String loopbackUrlForCode(String code) => Uri(
+    scheme: 'http',
+    host: '127.0.0.1',
+    port: port,
+    path: '/',
+    queryParameters: {'code': code, 'state': state},
+  ).toString();
+
+  Map<String, dynamic> toJson() => {
+    'state': state,
+    'port': port,
+    'client_name': clientName,
+  };
+
+  static McpBrowserContext? fromUri(Uri uri) {
+    final state = (uri.queryParameters['state'] ?? '').trim();
+    final port =
+        int.tryParse(uri.queryParameters['port'] ?? '') ??
+        int.tryParse(uri.queryParameters['callback_port'] ?? '');
+    final clientName = _cleanClientName(
+      uri.queryParameters['client_name'] ??
+          uri.queryParameters['editor_name'] ??
+          uri.queryParameters['editor'] ??
+          uri.queryParameters['client'],
+    );
+
+    if (state.isEmpty || port == null || port <= 0) return null;
+    return McpBrowserContext(state: state, port: port, clientName: clientName);
+  }
+
+  static McpBrowserContext? read() {
+    final raw = web.window.sessionStorage.getItem(_mcpContextStorageKey);
+    if (raw == null || raw.trim().isEmpty) return null;
+    try {
+      final decoded = json.decode(raw);
+      if (decoded is! Map) return null;
+      final map = Map<String, dynamic>.from(decoded);
+      final state = (map['state'] ?? '').toString().trim();
+      final port = map['port'] is num
+          ? (map['port'] as num).toInt()
+          : int.tryParse((map['port'] ?? '').toString());
+      if (state.isEmpty || port == null || port <= 0) return null;
+      return McpBrowserContext(
+        state: state,
+        port: port,
+        clientName: _cleanClientName(map['client_name']?.toString()),
+      );
+    } catch (_) {
+      return null;
+    }
+  }
+
+  static McpBrowserContext? readOrCapture(Uri uri) {
+    final fromUri = McpBrowserContext.fromUri(uri);
+    if (fromUri != null) {
+      persist(fromUri);
+      return fromUri;
+    }
+    return read();
+  }
+
+  static void persist(McpBrowserContext context) {
+    web.window.sessionStorage.setItem(
+      _mcpContextStorageKey,
+      json.encode(context.toJson()),
+    );
+  }
+
+  static void clear() {
+    web.window.sessionStorage.removeItem(_mcpContextStorageKey);
+  }
+
+  static String? _cleanClientName(String? value) {
+    final trimmed = (value ?? '').trim();
+    return trimmed.isEmpty ? null : trimmed;
+  }
+}

--- a/lib/features/mcp/data/mcp_service.dart
+++ b/lib/features/mcp/data/mcp_service.dart
@@ -1,0 +1,117 @@
+import 'package:dio/dio.dart';
+import 'package:nova3d_frontend/core/constants.dart';
+import 'package:nova3d_frontend/features/auth/data/auth_service.dart';
+import 'package:nova3d_frontend/features/mcp/models/mcp_models.dart';
+
+class McpException implements Exception {
+  McpException(this.message, {this.isAuthError = false});
+
+  final String message;
+  final bool isAuthError;
+
+  @override
+  String toString() => message;
+}
+
+class McpService {
+  McpService(this._auth) {
+    _dio = Dio(
+      BaseOptions(
+        baseUrl: kApiBaseUrl,
+        connectTimeout: const Duration(seconds: 10),
+        receiveTimeout: const Duration(seconds: 15),
+        headers: {'Content-Type': 'application/json'},
+      ),
+    );
+  }
+
+  final AuthService _auth;
+  late final Dio _dio;
+
+  Future<McpStatus> getStatus() async {
+    try {
+      final response = await _dio.get(
+        '/mcp/status',
+        options: await _authOptions(),
+      );
+      final data = response.data;
+      if (data is Map<String, dynamic>) return McpStatus.fromJson(data);
+      if (data is Map) {
+        return McpStatus.fromJson(Map<String, dynamic>.from(data));
+      }
+      throw McpException('Nova3D returned an unexpected MCP status response.');
+    } on DioException catch (e) {
+      throw _exceptionFromDio(e);
+    } on AuthException catch (e) {
+      throw McpException(e.message, isAuthError: true);
+    }
+  }
+
+  Future<String> createSessionCode() async {
+    try {
+      final response = await _dio.post(
+        '/mcp/session/create',
+        data: const <String, dynamic>{},
+        options: await _authOptions(),
+      );
+      final data = response.data;
+      if (data is Map) {
+        final sessionCode = (data['session_code'] ?? '').toString().trim();
+        if (sessionCode.isNotEmpty) return sessionCode;
+      }
+      throw McpException('Nova3D did not return an MCP session code.');
+    } on DioException catch (e) {
+      throw _exceptionFromDio(e);
+    } on AuthException catch (e) {
+      throw McpException(e.message, isAuthError: true);
+    }
+  }
+
+  Future<Options> _authOptions() async {
+    final token = await _auth.getToken();
+    if (token == null || token.isEmpty) {
+      throw McpException('Please sign in again.', isAuthError: true);
+    }
+    return Options(headers: {'Authorization': 'Bearer $token'});
+  }
+
+  McpException _exceptionFromDio(DioException e) {
+    final status = e.response?.statusCode;
+    if (status == 401 || status == 403) {
+      return McpException(
+        'Your session expired. Please sign in again.',
+        isAuthError: true,
+      );
+    }
+    if (status == 422) {
+      return McpException(
+        _safeDetailMessage(e.response?.data) ??
+            'Nova3D could not complete MCP setup yet.',
+      );
+    }
+    if (e.type == DioExceptionType.connectionError ||
+        e.type == DioExceptionType.connectionTimeout ||
+        e.type == DioExceptionType.unknown) {
+      return McpException(
+        'Could not reach Nova3D setup services. Check your connection and try again.',
+      );
+    }
+    return McpException(
+      _safeDetailMessage(e.response?.data) ??
+          'Nova3D MCP setup failed (${status ?? 'unknown'}).',
+    );
+  }
+
+  String? _safeDetailMessage(Object? data) {
+    if (data is! Map) return null;
+    final detail = data['detail'];
+    if (detail is String && detail.trim().isNotEmpty) return detail.trim();
+    if (detail is Map) {
+      final message = detail['message'];
+      if (message is String && message.trim().isNotEmpty) {
+        return message.trim();
+      }
+    }
+    return null;
+  }
+}

--- a/lib/features/mcp/models/mcp_models.dart
+++ b/lib/features/mcp/models/mcp_models.dart
@@ -1,0 +1,115 @@
+class McpIdentity {
+  const McpIdentity({
+    required this.userId,
+    required this.email,
+    required this.tenantId,
+  });
+
+  final String userId;
+  final String email;
+  final String tenantId;
+
+  factory McpIdentity.fromJson(Map<String, dynamic> json) => McpIdentity(
+    userId: (json['user_id'] ?? '').toString(),
+    email: (json['email'] ?? '').toString(),
+    tenantId: (json['tenant_id'] ?? '').toString(),
+  );
+}
+
+class McpSessionInfo {
+  const McpSessionInfo({required this.established, this.expiresAt});
+
+  final bool established;
+  final DateTime? expiresAt;
+
+  factory McpSessionInfo.fromJson(Map<String, dynamic> json) => McpSessionInfo(
+    established: json['established'] == true,
+    expiresAt: _dateTimeFromJson(json['expires_at']),
+  );
+}
+
+class McpCredits {
+  const McpCredits({
+    required this.balance,
+    required this.reserved,
+    required this.available,
+    required this.funded,
+  });
+
+  final int balance;
+  final int reserved;
+  final int available;
+  final bool funded;
+
+  factory McpCredits.fromJson(Map<String, dynamic> json) => McpCredits(
+    balance: _intFromJson(json['balance']),
+    reserved: _intFromJson(json['reserved']),
+    available: _intFromJson(json['available']),
+    funded: json['funded'] == true,
+  );
+}
+
+class McpStatus {
+  const McpStatus({
+    required this.authenticated,
+    required this.identity,
+    required this.mcpSession,
+    required this.credits,
+    required this.generationReady,
+    required this.nextAction,
+    required this.nextActionUrl,
+  });
+
+  final bool authenticated;
+  final McpIdentity? identity;
+  final McpSessionInfo? mcpSession;
+  final McpCredits? credits;
+  final bool generationReady;
+  final String? nextAction;
+  final String? nextActionUrl;
+
+  bool get needsPurchase =>
+      nextAction == 'purchase_credits' ||
+      (credits != null && !credits!.funded && credits!.available <= 0);
+
+  factory McpStatus.fromJson(Map<String, dynamic> json) => McpStatus(
+    authenticated: json['authenticated'] == true,
+    identity: json['identity'] is Map<String, dynamic>
+        ? McpIdentity.fromJson(json['identity'] as Map<String, dynamic>)
+        : json['identity'] is Map
+        ? McpIdentity.fromJson(
+            Map<String, dynamic>.from(json['identity'] as Map),
+          )
+        : null,
+    mcpSession: json['mcp_session'] is Map<String, dynamic>
+        ? McpSessionInfo.fromJson(json['mcp_session'] as Map<String, dynamic>)
+        : json['mcp_session'] is Map
+        ? McpSessionInfo.fromJson(
+            Map<String, dynamic>.from(json['mcp_session'] as Map),
+          )
+        : null,
+    credits: json['credits'] is Map<String, dynamic>
+        ? McpCredits.fromJson(json['credits'] as Map<String, dynamic>)
+        : json['credits'] is Map
+        ? McpCredits.fromJson(Map<String, dynamic>.from(json['credits'] as Map))
+        : null,
+    generationReady: json['generation_ready'] == true,
+    nextAction: _stringOrNull(json['next_action']),
+    nextActionUrl: _stringOrNull(json['next_action_url']),
+  );
+}
+
+int _intFromJson(Object? value) {
+  if (value is num) return value.toInt();
+  return int.tryParse((value ?? '').toString()) ?? 0;
+}
+
+DateTime? _dateTimeFromJson(Object? value) {
+  if (value is! String || value.trim().isEmpty) return null;
+  return DateTime.tryParse(value);
+}
+
+String? _stringOrNull(Object? value) {
+  final parsed = (value ?? '').toString().trim();
+  return parsed.isEmpty || parsed == 'null' ? null : parsed;
+}

--- a/lib/features/mcp/presentation/mcp_complete_page.dart
+++ b/lib/features/mcp/presentation/mcp_complete_page.dart
@@ -1,0 +1,234 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:nova3d_frontend/features/auth/state/auth_provider.dart';
+import 'package:nova3d_frontend/features/mcp/data/mcp_browser_context.dart';
+import 'package:nova3d_frontend/features/mcp/models/mcp_models.dart';
+import 'package:nova3d_frontend/features/mcp/presentation/mcp_shared.dart';
+import 'package:nova3d_frontend/features/mcp/state/mcp_provider.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+class McpCompletePage extends ConsumerStatefulWidget {
+  const McpCompletePage({super.key});
+
+  @override
+  ConsumerState<McpCompletePage> createState() => _McpCompletePageState();
+}
+
+class _McpCompletePageState extends ConsumerState<McpCompletePage> {
+  bool _initialized = false;
+  bool _preparingLoopback = false;
+  String? _handoffUrl;
+  Timer? _pollTimer;
+
+  @override
+  void dispose() {
+    _pollTimer?.cancel();
+    super.dispose();
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (_initialized) return;
+    _initialized = true;
+    WidgetsBinding.instance.addPostFrameCallback((_) => _bootstrap());
+  }
+
+  Future<void> _bootstrap() async {
+    final auth = ref.read(authProvider);
+    if (auth.valueOrNull == null) {
+      if (mounted) context.go('/mcp/connect');
+      return;
+    }
+
+    final status = await ref.read(mcpProvider.notifier).refreshStatus();
+    if (!mounted || status == null) return;
+
+    if (!status.authenticated ||
+        status.nextAction == 'sign_in' ||
+        status.nextAction == 'session_expired') {
+      context.go('/mcp/connect');
+      return;
+    }
+    if (status.needsPurchase) {
+      context.go('/mcp/no-credits');
+      return;
+    }
+
+    final contextData = McpBrowserContext.readOrCapture(Uri.base);
+    if (contextData == null || !contextData.isValid) return;
+
+    setState(() => _preparingLoopback = true);
+    final sessionCode = await ref
+        .read(mcpProvider.notifier)
+        .createSessionCode();
+    if (!mounted) return;
+    setState(() {
+      _preparingLoopback = false;
+      _handoffUrl = sessionCode == null
+          ? null
+          : contextData.loopbackUrlForCode(sessionCode);
+    });
+    _startPolling();
+  }
+
+  Future<void> _openLoopback() async {
+    final handoffUrl = _handoffUrl;
+    if (handoffUrl == null) return;
+    final uri = Uri.tryParse(handoffUrl);
+    if (uri == null) return;
+    final launched = await launchUrl(
+      uri,
+      mode: LaunchMode.platformDefault,
+      webOnlyWindowName: '_blank',
+    );
+    if (!launched && mounted) {
+      ref.read(mcpProvider.notifier).clearError();
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('Could not reach the local MCP callback.'),
+        ),
+      );
+    }
+  }
+
+  void _startPolling() {
+    _pollTimer?.cancel();
+    _pollTimer = Timer.periodic(const Duration(seconds: 3), (_) async {
+      if (!mounted) return;
+      final status = await ref.read(mcpProvider.notifier).refreshStatus();
+      if (!mounted || status == null) return;
+      if (status.needsPurchase) {
+        _pollTimer?.cancel();
+        context.go('/mcp/no-credits');
+        return;
+      }
+      if (!status.authenticated ||
+          status.nextAction == 'sign_in' ||
+          status.nextAction == 'session_expired') {
+        _pollTimer?.cancel();
+        context.go('/mcp/connect');
+        return;
+      }
+      if (status.mcpSession?.established == true || status.generationReady) {
+        _pollTimer?.cancel();
+      }
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final auth = ref.watch(authProvider);
+    final mcp = ref.watch(mcpProvider);
+    final status = mcp.status;
+    final contextData = McpBrowserContext.read();
+    final identity =
+        status?.identity ?? _identityFromAuth(auth.valueOrNull?.email);
+    final canContinue =
+        _handoffUrl != null && !mcp.loadingStatus && !_preparingLoopback;
+
+    return McpScaffold(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          McpHeader(
+            badge: 'mcp setup',
+            title: status?.generationReady == true
+                ? 'Nova3D is ready'
+                : 'Finish editor connection',
+            subtitle:
+                'Your Nova3D browser sign-in is complete. Continue the local editor handoff so your MCP session can be established without copying a token.',
+          ),
+          const SizedBox(height: 24),
+          McpInfoPanel(
+            children: [
+              McpStatusRow(
+                label: 'Account',
+                value: identity?.email.isNotEmpty == true
+                    ? identity!.email
+                    : 'Signed-in Nova3D account',
+              ),
+              McpStatusRow(
+                label: 'Credits',
+                value: status?.credits == null
+                    ? 'Checking credits...'
+                    : '${status!.credits!.available} available',
+              ),
+              McpStatusRow(
+                label: 'MCP session',
+                value: status?.mcpSession?.established == true
+                    ? 'Established'
+                    : status?.nextAction == 'service_unavailable'
+                    ? 'Nova3D setup service unavailable'
+                    : _handoffUrl != null
+                    ? 'Waiting for local editor callback'
+                    : 'Preparing one-time handoff',
+              ),
+              McpStatusRow(
+                label: 'Editor',
+                value: contextData?.clientName ?? 'Connected local editor',
+              ),
+            ],
+          ),
+          if (mcp.error != null) ...[
+            const SizedBox(height: 18),
+            McpMessageBanner(message: mcp.error!, isError: true),
+          ] else if (status?.generationReady == true) ...[
+            const SizedBox(height: 18),
+            const McpMessageBanner(
+              message:
+                  'Nova3D confirmed your account is funded and ready. Continue in your editor to complete the local MCP session handoff.',
+            ),
+          ] else if (status?.nextAction == 'service_unavailable') ...[
+            const SizedBox(height: 18),
+            const McpMessageBanner(
+              message:
+                  'Nova3D setup is temporarily unavailable. Keep this tab open and check again in a moment.',
+              isError: true,
+            ),
+          ],
+          const SizedBox(height: 24),
+          if (mcp.loadingStatus || _preparingLoopback)
+            const Padding(
+              padding: EdgeInsets.symmetric(vertical: 8),
+              child: CircularProgressIndicator(),
+            )
+          else ...[
+            McpPrimaryButton(
+              label: canContinue
+                  ? 'Continue in your editor'
+                  : 'Refresh Nova3D status',
+              onTap: canContinue ? _openLoopback : _bootstrap,
+            ),
+            const SizedBox(height: 12),
+            McpSecondaryButton(
+              label: status?.needsPurchase == true
+                  ? 'Buy credits'
+                  : 'Check status again',
+              onTap: status?.needsPurchase == true
+                  ? () => context.go('/mcp/no-credits')
+                  : _bootstrap,
+            ),
+          ],
+          const SizedBox(height: 16),
+          Text(
+            'If the local editor callback does not complete immediately, keep this tab open and retry the editor handoff from your MCP setup surface.',
+            textAlign: TextAlign.center,
+            style: Theme.of(
+              context,
+            ).textTheme.bodySmall?.copyWith(height: 1.45),
+          ),
+        ],
+      ),
+    );
+  }
+
+  McpIdentity? _identityFromAuth(String? email) {
+    final trimmed = (email ?? '').trim();
+    if (trimmed.isEmpty) return null;
+    return McpIdentity(userId: '', email: trimmed, tenantId: '');
+  }
+}

--- a/lib/features/mcp/presentation/mcp_connect_page.dart
+++ b/lib/features/mcp/presentation/mcp_connect_page.dart
@@ -1,0 +1,113 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:nova3d_frontend/features/auth/state/auth_provider.dart';
+import 'package:nova3d_frontend/features/mcp/data/mcp_browser_context.dart';
+import 'package:nova3d_frontend/features/mcp/presentation/mcp_shared.dart';
+import 'package:web/web.dart' as web;
+
+class McpConnectPage extends ConsumerStatefulWidget {
+  const McpConnectPage({super.key});
+
+  @override
+  ConsumerState<McpConnectPage> createState() => _McpConnectPageState();
+}
+
+class _McpConnectPageState extends ConsumerState<McpConnectPage> {
+  bool _startingGoogle = false;
+  String? _error;
+  bool _autoProgressed = false;
+
+  Future<void> _startGoogleSignIn() async {
+    final contextData = McpBrowserContext.readOrCapture(Uri.base);
+    if (contextData != null) McpBrowserContext.persist(contextData);
+
+    setState(() {
+      _startingGoogle = true;
+      _error = null;
+    });
+    try {
+      final url = await ref
+          .read(authServiceProvider)
+          .getGoogleAuthorizationUrl();
+      web.window.location.href = url;
+    } catch (_) {
+      if (mounted) {
+        setState(() {
+          _startingGoogle = false;
+          _error = 'Failed to start Nova3D sign-in.';
+        });
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final auth = ref.watch(authProvider);
+    final contextData = McpBrowserContext.readOrCapture(Uri.base);
+    final user = auth.valueOrNull;
+
+    if (!_autoProgressed && !auth.isLoading && user != null) {
+      _autoProgressed = true;
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted) context.go('/mcp/complete');
+      });
+    }
+
+    final clientName = contextData?.clientName ?? 'your editor';
+    final missingContext = contextData == null || !contextData.isValid;
+
+    return McpScaffold(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          McpHeader(
+            badge: 'mcp setup',
+            title: 'Connect Nova3D',
+            subtitle:
+                'Sign in to link Nova3D with $clientName. Nova3D will use your normal account wallet, and paid generation will only start once credits are ready.',
+          ),
+          const SizedBox(height: 24),
+          McpInfoPanel(
+            children: [
+              McpStatusRow(
+                label: 'Step 1',
+                value: 'Sign in to your Nova3D account',
+              ),
+              McpStatusRow(
+                label: 'Step 2',
+                value: 'Confirm editor connection and local MCP session setup',
+              ),
+              const McpStatusRow(
+                label: 'Step 3',
+                value: 'Buy credits only if your account is currently unfunded',
+              ),
+            ],
+          ),
+          if (missingContext) ...[
+            const SizedBox(height: 18),
+            const McpMessageBanner(
+              message:
+                  'This browser page is missing the MCP handoff details from your editor. Restart setup from the Nova3D MCP command in your editor.',
+              isError: true,
+            ),
+          ],
+          if (_error != null) ...[
+            const SizedBox(height: 18),
+            McpMessageBanner(message: _error!, isError: true),
+          ],
+          const SizedBox(height: 24),
+          McpPrimaryButton(
+            label: user != null ? 'Continue setup' : 'Continue with Google',
+            onTap: missingContext
+                ? null
+                : user != null
+                ? () => context.go('/mcp/complete')
+                : _startGoogleSignIn,
+            loading: _startingGoogle || auth.isLoading,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/mcp/presentation/mcp_no_credits_page.dart
+++ b/lib/features/mcp/presentation/mcp_no_credits_page.dart
@@ -1,0 +1,141 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:nova3d_frontend/features/auth/state/auth_provider.dart';
+import 'package:nova3d_frontend/features/mcp/data/mcp_browser_context.dart';
+import 'package:nova3d_frontend/features/mcp/presentation/mcp_shared.dart';
+import 'package:nova3d_frontend/features/mcp/state/mcp_provider.dart';
+import 'package:nova3d_frontend/features/subscription/models/billing_models.dart';
+import 'package:nova3d_frontend/features/subscription/state/billing_provider.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+class McpNoCreditsPage extends ConsumerStatefulWidget {
+  const McpNoCreditsPage({super.key});
+
+  @override
+  ConsumerState<McpNoCreditsPage> createState() => _McpNoCreditsPageState();
+}
+
+class _McpNoCreditsPageState extends ConsumerState<McpNoCreditsPage> {
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) async {
+      await ref.read(mcpProvider.notifier).refreshStatus();
+      await ref.read(billingProvider.notifier).load();
+      await ref.read(billingProvider.notifier).refreshWallet();
+    });
+  }
+
+  Future<void> _startCheckout(BillingTier tier) async {
+    final url = await ref
+        .read(billingProvider.notifier)
+        .createCheckout(tier, source: BillingCheckoutSource.mcp);
+    if (!mounted || url == null) return;
+
+    final uri = Uri.tryParse(url);
+    if (uri == null || !uri.hasScheme) {
+      ref
+          .read(billingProvider.notifier)
+          .setError('Billing returned an invalid checkout URL.');
+      return;
+    }
+
+    final launched = await launchUrl(
+      uri,
+      mode: LaunchMode.platformDefault,
+      webOnlyWindowName: '_self',
+    );
+    if (!launched && mounted) {
+      ref
+          .read(billingProvider.notifier)
+          .setError('Could not open Stripe checkout.');
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final auth = ref.watch(authProvider);
+    final mcp = ref.watch(mcpProvider);
+    final billing = ref.watch(billingProvider);
+    final tiers = billing.tiers;
+    final selectedTier = tiers.isEmpty
+        ? null
+        : tiers.firstWhere((tier) => tier.isPopular, orElse: () => tiers.first);
+    final email = mcp.status?.identity?.email.isNotEmpty == true
+        ? mcp.status!.identity!.email
+        : (auth.valueOrNull?.email.isNotEmpty == true
+              ? auth.valueOrNull!.email
+              : 'Signed-in Nova3D account');
+    final available =
+        mcp.status?.credits?.available ?? billing.wallet?.available ?? 0;
+    final clientName = McpBrowserContext.read()?.clientName ?? 'your editor';
+
+    return McpScaffold(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          McpHeader(
+            badge: 'credits required',
+            title: 'Account connected, credits needed',
+            subtitle:
+                'Nova3D is linked to $clientName, but generation is not ready until this account has credits.',
+          ),
+          const SizedBox(height: 24),
+          McpInfoPanel(
+            tint: const Color(0xFFFFF2E6),
+            children: [
+              McpStatusRow(label: 'Account', value: email),
+              McpStatusRow(label: 'Available credits', value: '$available'),
+              const McpStatusRow(
+                label: 'Wallet model',
+                value: 'Web and MCP use the same Nova3D credit balance.',
+              ),
+            ],
+          ),
+          if (mcp.error != null || billing.error != null) ...[
+            const SizedBox(height: 18),
+            McpMessageBanner(
+              message: mcp.error ?? billing.error!,
+              isError: true,
+            ),
+          ],
+          const SizedBox(height: 18),
+          const McpMessageBanner(
+            message:
+                'Your sign-in is complete. Buy credits for this account, then return to your editor and Nova3D MCP will re-check readiness.',
+          ),
+          const SizedBox(height: 24),
+          McpPrimaryButton(
+            label: selectedTier == null
+                ? 'Refresh credit packages'
+                : 'Buy ${selectedTier.credits} credits',
+            onTap: billing.checkoutTierId != null
+                ? null
+                : selectedTier == null
+                ? () => ref.read(billingProvider.notifier).load(force: true)
+                : () => _startCheckout(selectedTier),
+            loading:
+                selectedTier != null &&
+                billing.checkoutTierId == selectedTier.tierId,
+          ),
+          const SizedBox(height: 12),
+          McpSecondaryButton(
+            label: 'I already purchased, check again',
+            onTap: () async {
+              await ref.read(mcpProvider.notifier).refreshStatus();
+              await ref.read(billingProvider.notifier).refreshWallet();
+              if (!context.mounted) return;
+              final updated = ref.read(mcpProvider).status;
+              if (updated?.needsPurchase == false &&
+                  (updated?.generationReady == true ||
+                      (updated?.credits?.available ?? 0) > 0)) {
+                context.go('/mcp/complete');
+              }
+            },
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/mcp/presentation/mcp_purchase_success_page.dart
+++ b/lib/features/mcp/presentation/mcp_purchase_success_page.dart
@@ -1,0 +1,144 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:nova3d_frontend/features/auth/state/auth_provider.dart';
+import 'package:nova3d_frontend/features/mcp/data/mcp_browser_context.dart';
+import 'package:nova3d_frontend/features/mcp/presentation/mcp_shared.dart';
+import 'package:nova3d_frontend/features/mcp/state/mcp_provider.dart';
+import 'package:nova3d_frontend/features/subscription/state/billing_provider.dart';
+
+class McpPurchaseSuccessPage extends ConsumerStatefulWidget {
+  const McpPurchaseSuccessPage({super.key});
+
+  @override
+  ConsumerState<McpPurchaseSuccessPage> createState() =>
+      _McpPurchaseSuccessPageState();
+}
+
+class _McpPurchaseSuccessPageState
+    extends ConsumerState<McpPurchaseSuccessPage> {
+  String? _verifiedSessionId;
+  Timer? _pollTimer;
+
+  @override
+  void dispose() {
+    _pollTimer?.cancel();
+    super.dispose();
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) => _bootstrap());
+  }
+
+  Future<void> _bootstrap() async {
+    final sessionId =
+        Uri.base.queryParameters['session_id'] ??
+        Uri.base.queryParameters['checkout_session_id'];
+    if (sessionId != null &&
+        sessionId.trim().isNotEmpty &&
+        sessionId != _verifiedSessionId) {
+      _verifiedSessionId = sessionId;
+      await ref.read(billingProvider.notifier).verifyCheckout(sessionId);
+    }
+    await ref.read(mcpProvider.notifier).refreshStatus();
+    await ref.read(billingProvider.notifier).refreshWallet();
+    _syncPolling();
+  }
+
+  void _syncPolling() {
+    final ready = _isReady();
+    _pollTimer?.cancel();
+    if (ready) return;
+    _pollTimer = Timer.periodic(const Duration(seconds: 3), (_) async {
+      if (!mounted) return;
+      await ref.read(mcpProvider.notifier).refreshStatus();
+      await ref.read(billingProvider.notifier).refreshWallet();
+      if (!mounted) return;
+      if (_isReady()) {
+        _pollTimer?.cancel();
+      }
+    });
+  }
+
+  bool _isReady() {
+    final mcp = ref.read(mcpProvider);
+    final billing = ref.read(billingProvider);
+    final available =
+        mcp.status?.credits?.available ?? billing.wallet?.available ?? 0;
+    return mcp.status?.generationReady == true || available > 0;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final auth = ref.watch(authProvider);
+    final mcp = ref.watch(mcpProvider);
+    final billing = ref.watch(billingProvider);
+    final available =
+        mcp.status?.credits?.available ?? billing.wallet?.available;
+    final clientName = McpBrowserContext.read()?.clientName ?? 'your editor';
+    final ready = mcp.status?.generationReady == true || (available ?? 0) > 0;
+
+    return McpScaffold(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          McpHeader(
+            badge: 'purchase complete',
+            title: ready ? 'Nova3D funding confirmed' : 'Refreshing credits',
+            subtitle: ready
+                ? 'Your Nova3D account has credits again. Return to $clientName to finish the MCP setup handoff.'
+                : 'Stripe confirmed the payment. Nova3D is refreshing your account balance now.',
+          ),
+          const SizedBox(height: 24),
+          McpInfoPanel(
+            children: [
+              McpStatusRow(
+                label: 'Account',
+                value: mcp.status?.identity?.email.isNotEmpty == true
+                    ? mcp.status!.identity!.email
+                    : (auth.valueOrNull?.email.isNotEmpty == true
+                          ? auth.valueOrNull!.email
+                          : 'Signed-in Nova3D account'),
+              ),
+              McpStatusRow(
+                label: 'Available credits',
+                value: available == null ? 'Refreshing...' : '$available',
+              ),
+              McpStatusRow(
+                label: 'Next step',
+                value: ready
+                    ? 'Return to your editor and continue setup.'
+                    : 'Keep this tab open or check again in a moment.',
+              ),
+            ],
+          ),
+          if (mcp.error != null || billing.error != null) ...[
+            const SizedBox(height: 18),
+            McpMessageBanner(
+              message: mcp.error ?? billing.error!,
+              isError: true,
+            ),
+          ] else if (billing.notice != null) ...[
+            const SizedBox(height: 18),
+            McpMessageBanner(message: billing.notice!),
+          ],
+          const SizedBox(height: 24),
+          McpPrimaryButton(
+            label: ready ? 'Continue setup in browser' : 'Check again',
+            onTap: ready ? () => context.go('/mcp/complete') : _bootstrap,
+            loading: billing.verifyingCheckout || mcp.loadingStatus,
+          ),
+          const SizedBox(height: 12),
+          McpSecondaryButton(
+            label: ready ? 'Close tab and return to editor' : 'Back to credits',
+            onTap: ready ? null : () => context.go('/mcp/no-credits'),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/mcp/presentation/mcp_shared.dart
+++ b/lib/features/mcp/presentation/mcp_shared.dart
@@ -1,0 +1,224 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:nova3d_frontend/core/theme.dart';
+import 'package:nova3d_frontend/shared/widgets/grid_background.dart';
+import 'package:nova3d_frontend/shared/widgets/nova_cube.dart';
+
+class McpScaffold extends StatelessWidget {
+  const McpScaffold({super.key, required this.child});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) => Scaffold(
+    backgroundColor: kCream,
+    body: GridBackground(
+      child: Center(
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.all(24),
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 640),
+            child: Container(
+              padding: const EdgeInsets.all(28),
+              decoration: kChunkyCard(radius: 8),
+              child: child,
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+}
+
+class McpHeader extends StatelessWidget {
+  const McpHeader({
+    super.key,
+    required this.title,
+    required this.subtitle,
+    this.badge,
+  });
+
+  final String title;
+  final String subtitle;
+  final String? badge;
+
+  @override
+  Widget build(BuildContext context) => Column(
+    children: [
+      const NovaCube(size: 56),
+      const SizedBox(height: 18),
+      if (badge != null) ...[
+        Container(
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 5),
+          decoration: BoxDecoration(
+            color: kMintBg,
+            borderRadius: BorderRadius.circular(999),
+            border: Border.all(color: kInk, width: 1.3),
+          ),
+          child: Text(badge!, style: kSilkscreen(10, color: kInk)),
+        ),
+        const SizedBox(height: 14),
+      ],
+      Text(title, textAlign: TextAlign.center, style: kVt323(46)),
+      const SizedBox(height: 10),
+      Text(
+        subtitle,
+        textAlign: TextAlign.center,
+        style: Theme.of(
+          context,
+        ).textTheme.bodyMedium?.copyWith(height: 1.45, color: kInkSoft),
+      ),
+    ],
+  );
+}
+
+class McpInfoPanel extends StatelessWidget {
+  const McpInfoPanel({super.key, required this.children, this.tint = kMintBg});
+
+  final List<Widget> children;
+  final Color tint;
+
+  @override
+  Widget build(BuildContext context) => Container(
+    width: double.infinity,
+    padding: const EdgeInsets.all(18),
+    decoration: BoxDecoration(
+      color: tint,
+      borderRadius: BorderRadius.circular(8),
+      border: Border.all(color: kInk, width: 1.2),
+    ),
+    child: Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: children,
+    ),
+  );
+}
+
+class McpMessageBanner extends StatelessWidget {
+  const McpMessageBanner({
+    super.key,
+    required this.message,
+    this.isError = false,
+  });
+
+  final String message;
+  final bool isError;
+
+  @override
+  Widget build(BuildContext context) => Container(
+    width: double.infinity,
+    padding: const EdgeInsets.all(14),
+    decoration: BoxDecoration(
+      color: isError ? kPinkBg : kMintBg,
+      borderRadius: BorderRadius.circular(8),
+      border: Border.all(color: isError ? kErrorRed : kMint, width: 1.2),
+    ),
+    child: Text(
+      message,
+      style: GoogleFonts.inter(color: kInk, fontSize: 13, height: 1.4),
+    ),
+  );
+}
+
+class McpPrimaryButton extends StatelessWidget {
+  const McpPrimaryButton({
+    super.key,
+    required this.label,
+    required this.onTap,
+    this.loading = false,
+  });
+
+  final String label;
+  final VoidCallback? onTap;
+  final bool loading;
+
+  @override
+  Widget build(BuildContext context) => SizedBox(
+    width: double.infinity,
+    child: FilledButton(
+      onPressed: loading ? null : onTap,
+      style: FilledButton.styleFrom(
+        backgroundColor: kPink,
+        foregroundColor: kInk,
+        padding: const EdgeInsets.symmetric(vertical: 16),
+        textStyle: kSilkscreen(11, color: kInk),
+        side: const BorderSide(color: kInk, width: 1.4),
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(10)),
+      ),
+      child: loading
+          ? const SizedBox(
+              width: 18,
+              height: 18,
+              child: CircularProgressIndicator(strokeWidth: 2, color: kInk),
+            )
+          : Text(label),
+    ),
+  );
+}
+
+class McpSecondaryButton extends StatelessWidget {
+  const McpSecondaryButton({
+    super.key,
+    required this.label,
+    required this.onTap,
+  });
+
+  final String label;
+  final VoidCallback? onTap;
+
+  @override
+  Widget build(BuildContext context) => SizedBox(
+    width: double.infinity,
+    child: OutlinedButton(
+      onPressed: onTap,
+      style: OutlinedButton.styleFrom(
+        foregroundColor: kInk,
+        padding: const EdgeInsets.symmetric(vertical: 16),
+        side: const BorderSide(color: kInk, width: 1.2),
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(10)),
+        textStyle: kSilkscreen(11, color: kInk),
+      ),
+      child: Text(label),
+    ),
+  );
+}
+
+class McpStatusRow extends StatelessWidget {
+  const McpStatusRow({super.key, required this.label, required this.value});
+
+  final String label;
+  final String value;
+
+  @override
+  Widget build(BuildContext context) => Padding(
+    padding: const EdgeInsets.only(bottom: 10),
+    child: Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        SizedBox(
+          width: 138,
+          child: Text(
+            label,
+            style: const TextStyle(
+              color: kInkSoft,
+              fontSize: 12,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+        ),
+        const SizedBox(width: 12),
+        Expanded(
+          child: Text(
+            value,
+            style: const TextStyle(
+              color: kInk,
+              fontSize: 13,
+              fontWeight: FontWeight.w600,
+              height: 1.35,
+            ),
+          ),
+        ),
+      ],
+    ),
+  );
+}

--- a/lib/features/mcp/state/mcp_provider.dart
+++ b/lib/features/mcp/state/mcp_provider.dart
@@ -1,0 +1,97 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:nova3d_frontend/features/auth/state/auth_provider.dart';
+import 'package:nova3d_frontend/features/mcp/data/mcp_service.dart';
+import 'package:nova3d_frontend/features/mcp/models/mcp_models.dart';
+
+final mcpServiceProvider = Provider<McpService>((ref) {
+  return McpService(ref.watch(authServiceProvider));
+});
+
+final mcpProvider = NotifierProvider<McpNotifier, McpState>(McpNotifier.new);
+
+class McpState {
+  const McpState({
+    this.status,
+    this.loadingStatus = false,
+    this.creatingSession = false,
+    this.sessionCode,
+    this.error,
+  });
+
+  final McpStatus? status;
+  final bool loadingStatus;
+  final bool creatingSession;
+  final String? sessionCode;
+  final String? error;
+
+  McpState copyWith({
+    McpStatus? status,
+    bool keepStatus = true,
+    bool? loadingStatus,
+    bool? creatingSession,
+    String? sessionCode,
+    bool clearSessionCode = false,
+    String? error,
+    bool clearError = false,
+  }) => McpState(
+    status: keepStatus ? (status ?? this.status) : status,
+    loadingStatus: loadingStatus ?? this.loadingStatus,
+    creatingSession: creatingSession ?? this.creatingSession,
+    sessionCode: clearSessionCode ? null : sessionCode ?? this.sessionCode,
+    error: clearError ? null : error ?? this.error,
+  );
+}
+
+class McpNotifier extends Notifier<McpState> {
+  @override
+  McpState build() => const McpState();
+
+  McpService get _service => ref.read(mcpServiceProvider);
+
+  Future<McpStatus?> refreshStatus() async {
+    if (state.loadingStatus) return state.status;
+    state = state.copyWith(loadingStatus: true, clearError: true);
+    try {
+      final status = await _service.getStatus();
+      state = state.copyWith(status: status, loadingStatus: false);
+      return status;
+    } on McpException catch (e) {
+      await _handleException(e);
+      state = state.copyWith(loadingStatus: false);
+      return null;
+    }
+  }
+
+  Future<String?> createSessionCode() async {
+    if (state.creatingSession) return state.sessionCode;
+    state = state.copyWith(
+      creatingSession: true,
+      clearError: true,
+      clearSessionCode: true,
+    );
+    try {
+      final code = await _service.createSessionCode();
+      state = state.copyWith(creatingSession: false, sessionCode: code);
+      return code;
+    } on McpException catch (e) {
+      await _handleException(e);
+      state = state.copyWith(creatingSession: false, clearSessionCode: true);
+      return null;
+    }
+  }
+
+  void clearError() {
+    state = state.copyWith(clearError: true);
+  }
+
+  void clearSessionCode() {
+    state = state.copyWith(clearSessionCode: true);
+  }
+
+  Future<void> _handleException(McpException e) async {
+    state = state.copyWith(error: e.message);
+    if (e.isAuthError) {
+      await ref.read(authProvider.notifier).signOut();
+    }
+  }
+}

--- a/lib/features/subscription/data/billing_service.dart
+++ b/lib/features/subscription/data/billing_service.dart
@@ -75,11 +75,14 @@ class BillingService {
     }
   }
 
-  Future<String> createCheckout(String tierId) async {
+  Future<String> createCheckout(
+    String tierId, {
+    BillingCheckoutSource source = BillingCheckoutSource.web,
+  }) async {
     try {
       final response = await _dio.post(
         '/billing/checkout',
-        data: {'tier_id': tierId},
+        data: {'tier_id': tierId, 'source': source.value},
         options: await _authOptions(),
       );
       final data = response.data;
@@ -182,4 +185,13 @@ class BillingService {
     }
     return null;
   }
+}
+
+enum BillingCheckoutSource { web, mcp }
+
+extension on BillingCheckoutSource {
+  String get value => switch (this) {
+    BillingCheckoutSource.web => 'web',
+    BillingCheckoutSource.mcp => 'mcp',
+  };
 }

--- a/lib/features/subscription/state/billing_provider.dart
+++ b/lib/features/subscription/state/billing_provider.dart
@@ -2,6 +2,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:nova3d_frontend/features/auth/state/auth_provider.dart';
 import 'package:nova3d_frontend/features/subscription/data/billing_service.dart';
 import 'package:nova3d_frontend/features/subscription/models/billing_models.dart';
+export 'package:nova3d_frontend/features/subscription/data/billing_service.dart'
+    show BillingCheckoutSource;
 
 final billingServiceProvider = Provider<BillingService>((ref) {
   return BillingService(ref.watch(authServiceProvider));
@@ -139,11 +141,14 @@ class BillingNotifier extends Notifier<BillingState> {
     }
   }
 
-  Future<String?> createCheckout(BillingTier tier) async {
+  Future<String?> createCheckout(
+    BillingTier tier, {
+    BillingCheckoutSource source = BillingCheckoutSource.web,
+  }) async {
     if (state.checkoutTierId != null) return null;
     state = state.copyWith(checkoutTierId: tier.tierId, clearError: true);
     try {
-      final url = await _service.createCheckout(tier.tierId);
+      final url = await _service.createCheckout(tier.tierId, source: source);
       state = state.copyWith(clearCheckoutTierId: true);
       return url;
     } on BillingException catch (e) {

--- a/test/mcp_models_test.dart
+++ b/test/mcp_models_test.dart
@@ -1,0 +1,68 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nova3d_frontend/features/mcp/data/mcp_browser_context.dart';
+import 'package:nova3d_frontend/features/mcp/models/mcp_models.dart';
+
+void main() {
+  test('parses MCP status and detects purchase requirement', () {
+    final status = McpStatus.fromJson({
+      'authenticated': true,
+      'identity': {
+        'user_id': 'user_123',
+        'email': 'user@example.com',
+        'tenant_id': 'ten_123',
+      },
+      'mcp_session': {
+        'established': false,
+        'expires_at': '2026-09-10T14:32:00Z',
+      },
+      'credits': {'balance': 0, 'reserved': 0, 'available': 0, 'funded': false},
+      'generation_ready': false,
+      'next_action': 'purchase_credits',
+      'next_action_url': '/subscription',
+    });
+
+    expect(status.authenticated, isTrue);
+    expect(status.identity?.email, 'user@example.com');
+    expect(status.mcpSession?.established, isFalse);
+    expect(status.credits?.available, 0);
+    expect(status.needsPurchase, isTrue);
+    expect(status.nextActionUrl, '/subscription');
+  });
+
+  test('treats funded ready status as not needing purchase', () {
+    final status = McpStatus.fromJson({
+      'authenticated': true,
+      'identity': {'user_id': 'user_123', 'email': 'user@example.com'},
+      'mcp_session': {'established': true},
+      'credits': {
+        'balance': 400,
+        'reserved': 50,
+        'available': 350,
+        'funded': true,
+      },
+      'generation_ready': true,
+      'next_action': null,
+      'next_action_url': null,
+    });
+
+    expect(status.generationReady, isTrue);
+    expect(status.needsPurchase, isFalse);
+  });
+
+  test('parses MCP browser context and builds loopback URL', () {
+    final context = McpBrowserContext.fromUri(
+      Uri.parse(
+        'https://nova3d.xyz/mcp/connect?state=nonce_123&port=5556&client_name=Cursor',
+      ),
+    );
+
+    expect(context, isNotNull);
+    expect(context!.state, 'nonce_123');
+    expect(context.port, 5556);
+    expect(context.clientName, 'Cursor');
+    expect(
+      context.loopbackUrlForCode('code_abc'),
+      'http://127.0.0.1:5556/?code=code_abc&state=nonce_123',
+    );
+  });
+}


### PR DESCRIPTION
## Summary
  - add MCP-specific frontend routes for connect, complete, no-credits, and purchase-success
  - branch OAuth callback into MCP flow when sign-in originated from MCP setup
  - add MCP session/status client state and pass `source: \"mcp\"` during checkout creation
  - add focused MCP status/context tests and tighten delayed handoff/purchase refresh UX

  ## Testing
  - flutter analyze
  - flutter test --platform chrome